### PR TITLE
feat: Add documentation link for base images.

### DIFF
--- a/index.html
+++ b/index.html
@@ -496,6 +496,8 @@
                                                 </div>
                                                 <a href="https://github.com/orgs/ublue-os/packages" target="_blank" class="btn btn-mod btn-large btn-round btn-hover-anim"><span>View All Base Images</span></a>
                                             </div>
+                                            <span style="color:#555;margin-top:30px;">Read our <a href="https://universal-blue.discourse.group/docs?topic=868" targt="_blank">documentation</a> on base images.</span>
+
                                             
                                         </div>                                
                                     </div>


### PR DESCRIPTION
Users who want the base image can be redirected to the documentation relevant to that.

![docs](https://github.com/nicknamenamenick/universal-blue-website-nick/assets/121328689/becc7a0f-5f0f-45ce-868e-5c535cccf812)